### PR TITLE
Enable title screen at launch

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Godot Wild Jam #87"
-run/main_scene="uid://dm3ra1iniucmx"
+run/main_scene="uid://dy7lqufy3iwjt"
 config/features=PackedStringArray("4.5", "Forward Plus")
 config/icon="res://icon.svg"
 
@@ -22,6 +22,12 @@ buses/default_bus_layout="res://Sound/default_bus_layout.tres"
 [debug]
 
 gdscript/warnings/untyped_declaration=1
+
+[display]
+
+window/size/viewport_width=1920
+window/size/viewport_height=1080
+window/stretch/mode="canvas_items"
 
 [input]
 


### PR DESCRIPTION
Simply swaps the launch screen from the 3D `main` to the `start_menu`.

https://github.com/user-attachments/assets/a7da50ff-db10-4320-a723-7a0eeb21cebf

