### PR TITLE
Revamp player hp bar with changing color and stop updating at 0 hp

### DIFF
--- a/UI/player_ui.gd
+++ b/UI/player_ui.gd
@@ -1,24 +1,34 @@
 extends Control
 
+const COLOR_HEALTH_HIGH = Color("#911b1b")  # Healthy red
+const COLOR_HEALTH_LOW = Color("#afb515")  # Sickly yellow
+
 var value_change: int = 0
 var pixel_shift_per_tick: float
 
 @onready var health_bar := $ProgressBar as ProgressBar
 @onready var falling_health := $FallingHealth/CPUParticles2D as CPUParticles2D
 @onready var full_health_position := falling_health.position.x
+@onready var health_bar_style_box: StyleBox = health_bar.get_theme_stylebox("fill").duplicate()
 
 
 func _ready() -> void:
 	pixel_shift_per_tick = health_bar.get_global_rect().size.x / 100
 	falling_health.move_local_x(-pixel_shift_per_tick * (100 - health_bar.value))
+	update_health_bar_color()
 
 
 func _process(_delta: float) -> void:
+	if health_bar.value <= 0:
+		return
+
 	if health_bar.value == 100:
 		falling_health.emitting = false
 	else:
 		falling_health.emitting = true
+
 	if value_change != 0:
+		update_health_bar_color()
 		health_bar.value += value_change
 		var position_shift := pixel_shift_per_tick * value_change
 		if (falling_health.position.x + position_shift) > full_health_position:
@@ -34,3 +44,15 @@ func _on_timer_timeout() -> void:
 
 func _on_main_damage_dealt(damage: Variant) -> void:
 	value_change = -damage
+
+
+func update_health_bar_color() -> void:
+	var ratio: float = health_bar.value / health_bar.max_value
+	var weighted_ratio: float = ease(ratio, 2.0)  # Transition colors quicker
+	var new_color: Color = COLOR_HEALTH_LOW.lerp(COLOR_HEALTH_HIGH, weighted_ratio)
+
+	health_bar_style_box.bg_color = new_color
+
+	health_bar.add_theme_stylebox_override("fill", health_bar_style_box)
+
+	falling_health.color = new_color

--- a/UI/player_ui.tscn
+++ b/UI/player_ui.tscn
@@ -14,7 +14,7 @@ shadow_size = 6
 shadow_offset = Vector2(5, 5)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_2q4oh"]
-bg_color = Color(0.37234777, 0.37234765, 9.62615e-08, 1)
+bg_color = Color(0.5686275, 0.105882354, 0.105882354, 1)
 corner_radius_top_left = 6
 corner_radius_top_right = 6
 corner_radius_bottom_right = 6


### PR DESCRIPTION
Proposing we update the player health bar to transition between red and yellow. Open to ideas for colors.

The current two are:
- Red: [#911b1b](https://www.color-hex.com/color/911b1b)
- Yellow: [#afb515](https://www.color-hex.com/color/afb515)

Video with sped up timer to show the progression:

https://github.com/user-attachments/assets/6b464cf3-faaa-459a-80d8-dd365fa37ef4

